### PR TITLE
Only remove passphraseSender if it is a function

### DIFF
--- a/lib/WiFi.js
+++ b/lib/WiFi.js
@@ -214,7 +214,7 @@ WiFi.prototype.join = function(ssid, passphrase, callback) {
           }
         }
         self.connman.Agent.on('RequestInput', passphraseSender);
-      	next();
+        next();
       }
     },
     // switch to this service
@@ -241,13 +241,19 @@ WiFi.prototype.join = function(ssid, passphrase, callback) {
           case STATES.READY:
           case STATES.ONLINE:
             targetService.removeListener('PropertyChanged', onChange);
-            self.connman.Agent.removeListener('RequestInput', passphraseSender);
+            if (typeof(passphraseSender) == 'function') {
+              self.connman.Agent.removeListener('RequestInput', passphraseSender);
+              passphraseSender = null
+            }
             next();
             break;
           case STATES.FAILURE:
             var err = new Error('Joining network failed (wrong password?)');
             targetService.removeListener('PropertyChanged', onChange);
-            self.connman.Agent.removeListener('RequestInput', passphraseSender);
+            if (typeof(passphraseSender) == 'function') {
+              self.connman.Agent.removeListener('RequestInput', passphraseSender);
+              passphraseSender = null
+            }
             next(err);
             // ToDo include error... (sometimes there is a Error property change, with a value like 'invalid-key')
             break;

--- a/lib/WiFi.js
+++ b/lib/WiFi.js
@@ -227,7 +227,6 @@ WiFi.prototype.join = function(ssid, passphrase, callback) {
     function(next) {
       targetService.connect(function(err, newAgent) {
         debug('connect response: ', err || ''/*,newAgent*/);
-        console.log()
         next(err);
       });
     },
@@ -251,6 +250,7 @@ WiFi.prototype.join = function(ssid, passphrase, callback) {
             clearTimeout(timeout);
             finishJoining()
             break;
+          case STATES.DISCONNECT:
           case STATES.FAILURE:
             clearTimeout(timeout);
             var err = new Error('Joining network failed (wrong password?)');

--- a/lib/WiFi.js
+++ b/lib/WiFi.js
@@ -11,6 +11,7 @@ var Parser = require('./Parser');
 var _super = Base.prototype;
 
 var _timeoutWiFiEnable = 3000;
+var _timeoutJoin = 35000;
 var _numGetServiceAttempts = 5;
 var _timeoutServicesChanged = 5000;
 var _numServicesChangedEvents = 2;
@@ -232,39 +233,36 @@ WiFi.prototype.join = function(ssid, passphrase, callback) {
     },
     // listen to state
     function(next) {
+      function finishJoining(err) {
+        targetService.removeListener('PropertyChanged', onChange);
+        if (typeof(passphraseSender) == 'function') {
+          self.connman.Agent.removeListener('RequestInput', passphraseSender);
+          passphraseSender = null
+        }
+        next(err);
+      }
       function onChange(type, value) {
         if (type !== 'State') return;
-        clearTimeout(timeout);
         debug('service State: ', value);
         switch (value) {
           // when wifi ready and online
           case STATES.READY:
           case STATES.ONLINE:
-            targetService.removeListener('PropertyChanged', onChange);
-            if (typeof(passphraseSender) == 'function') {
-              self.connman.Agent.removeListener('RequestInput', passphraseSender);
-              passphraseSender = null
-            }
-            next();
+            clearTimeout(timeout);
+            finishJoining()
             break;
           case STATES.FAILURE:
+            clearTimeout(timeout);
             var err = new Error('Joining network failed (wrong password?)');
-            targetService.removeListener('PropertyChanged', onChange);
-            if (typeof(passphraseSender) == 'function') {
-              self.connman.Agent.removeListener('RequestInput', passphraseSender);
-              passphraseSender = null
-            }
-            next(err);
+            finishJoining(err);
             // ToDo include error... (sometimes there is a Error property change, with a value like 'invalid-key')
             break;
         }
       }
       timeout = setTimeout(function(){
         var err = new Error('Joining network failed (Timeout)');
-        targetService.removeListener('PropertyChanged', onChange);
-        self.connman.Agent.removeListener('RequestInput', passphraseSender);
-        next(err);
-      }, 35000);
+        finishJoining(err);
+      }, _timeoutJoin);
       targetService.on('PropertyChanged', onChange);
     }
   ], function(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connman-simplified",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node.js package that simplifies Connman (Opensource connection manager) usage. Uses connman-api.",
   "keywords": [
     "internet",


### PR DESCRIPTION
Causes an error when trying to join a favorite network, as seen in resin-io/resin-wifi-connect#10
